### PR TITLE
Bump / rename 6to5 and remove dead dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ For now, it handles only a few resources. Building in parallel with
 [switcharoo](https://github.com/reddit/switcharoo).
 
 ```javascript
-// Convert snoode's es6 to es5. To use in browser, use 6to5-browserify and
+// Convert snoode's es6 to es5. To use in browser, use babelify and
 // compile in.
-require('6to5/register')(/^(?!.*es6\.js$).*\.js$/i);
+
+require('babel/register')({
+  ignore: false,
+  only: /.+(?:(?:\.es6\.js)|(?:.jsx))$/,
+  extensions: ['.js', '.es6.js'],
+  sourceMap: true,
+});
 
 // Require snoode.
 var api = require('snoode').v1;
@@ -33,5 +39,4 @@ api.comments.get({
 Caveats
 ------
 
-* Requires --harmony flag to run with node.
-* 
+* Requires iojs, or node with `--harmony` flag.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/ajacksified/snoode",
   "dependencies": {
-    "6to5": "^3.5.3",
-    "harmony-reflect": "^1.1.0",
+    "babel": "^4.3.0",
     "lru-cache": "^2.5.0",
     "q": "^1.1.2",
     "reddit-text-js": "^0.5.0",


### PR DESCRIPTION
6to5 renamed to 'babel', so this renames and upgrades.

Will require a minor version bump.

:eyeglasses: @btholt or @danehansen 