### PR TITLE
Decode APIv1's `websafe_json` encoding on JSON responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snoode",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "node and browser reddit api library",
   "main": "src/api.es6.js",
   "scripts": {


### PR DESCRIPTION
:eyeglasses: @ajacksified 

This should fix the HTML encoding in titles and such. Wasn't able to test it with Snoode itself, but I mounted the parser on a superagent request in the REPL and it seems to work.

We'll also need to remove the `cleanHtml` calls in `-mobile` so we don't double decode HTML (and possibly XSS ourselves.)