### PR TITLE
Add browserify babelify option to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
     "url": "https://github.com/ajacksified/snoode/issues"
   },
   "homepage": "https://github.com/ajacksified/snoode",
+  "browserify": {
+    "transform": [
+      [
+        "babelify"
+      ]
+    ]
+  },
   "dependencies": {
     "lru-cache": "^2.5.0",
     "q": "^1.2.0",


### PR DESCRIPTION
This change allows the babelify transform to be used in a browserify project (in my case, a browser extension project)

Adding `.es6.js` to `extensions` must be done on the main browserify instance (like, in the project's gulpfile). It doesn't seem to obey it if I only have it in Snoode's package.json for some reason.