### PR TITLE
Add basic stylesheet support

### DIFF
--- a/src/models/stylesheet.es6.js
+++ b/src/models/stylesheet.es6.js
@@ -1,0 +1,21 @@
+import Base from './base';
+
+// decode websafe_json encoding
+function unsafeJson(text) {
+    return text.replace(/&gt;/g, '>')
+        .replace(/&lt;/g, '<')
+        .replace(/&amp;/g, '&');
+}
+
+class Stylesheet extends Base {
+    constructor(props) {
+        props._type = 'Stylesheet';
+        super(props);
+    }
+
+    get stylesheet () {
+        return unsafeJson(this.get('stylesheet'));
+    }
+};
+
+export default Stylesheet;


### PR DESCRIPTION
This adds very basic support for subreddit stylesheets. I didn't add `POST` support for stylesheets in this commit, because the only kind of response one gets from `/api/subreddit_stylesheet` is meant for parsing with reddit's [`handleResponse`](https://github.com/reddit/reddit/blob/268a6297132bed80905ab8af605d93e36bd6042e/r2/r2/public/static/js/jquery.reddit.js#L126) function and it's kinda awkward to parse right now.

This allows grabbing the source of a subreddit's stylesheet (html entities unencoded) and its images.