### PR TITLE
Fix double decoding of embed code

### DIFF
--- a/src/models/link.es6.js
+++ b/src/models/link.es6.js
@@ -20,9 +20,7 @@ class Link extends Base {
       (props.media_embed && props.media_embed.content)
     );
 
-    if (content) {
-      content = content.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
-    } else if (props.selftext) {
+    if (!content && props.selftext) {
       content = process(props.selftext);
     }
 


### PR DESCRIPTION
:eyeglasses: @ajacksified 

We websafe_json decode further down in the stack now.

Haven't been able to test this, but from my reading of the JSON responses and the rest of Snoode this should be correct.