### PR TITLE
Add `thingId` validator

### DIFF
--- a/src/models/account.es6.js
+++ b/src/models/account.es6.js
@@ -4,6 +4,16 @@ class Account extends Base {
   constructor(props) {
     props._type = 'Account';
     super(props);
+
+    var account = this;
+
+    this.validators = {
+      thingId: function() {
+        var thingId = this.get('thingId');
+
+        return Base.validators.thingId(thingId);
+      }.bind(account),
+    };
   }
 };
 

--- a/src/models/base.es6.js
+++ b/src/models/base.es6.js
@@ -107,6 +107,17 @@ Base.validators = {
   minLength: function (s, l) {
     return Base.validators.string(s) && Base.validators.min(s.length, l);
   },
+
+  regex: function(s, expr) {
+    return expr.test(s);
+  },
+
+  thingId: function(id) {
+    var expr = new RegExp('t\\d_[0-9a-z]+', 'i');
+
+    return id == null || Base.validators.regex(id, expr);
+  },
+
 }
 
 export default Base;

--- a/src/models/comment.es6.js
+++ b/src/models/comment.es6.js
@@ -15,8 +15,9 @@ class Comment extends Base {
         return Base.validators.minLength(this.get('body'), 1);
       }.bind(comment),
       thingId: function() {
-        return Base.validators.minLength(this.get('thingId'), 6) &&
-               Base.validators.maxLength(this.get('thingId'), 10);
+        var thingId = this.get('thingId');
+
+        return Base.validators.thingId(thingId);
       }.bind(comment),
     };
   }

--- a/src/models/link.es6.js
+++ b/src/models/link.es6.js
@@ -14,8 +14,13 @@ class Link extends Base {
       }.bind(this),
       sendreplies: function() {
         return typeof this.get('sendreplies') === 'boolean';
-      }.bind(this)
-    }
+      }.bind(this),
+      thingId: function() {
+        var thingId = this.get('thingId');
+
+        return Base.validators.thingId(thingId);
+      }.bind(this),
+    };
   }
 
   get expandContent () {

--- a/test/models/account.js
+++ b/test/models/account.js
@@ -1,0 +1,33 @@
+require('babel/register')({
+  extensions: ['.js', '.es6.js']
+});
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai)
+
+var Account = require('../../src/api').models.Account;
+
+describe('Account model', function() {
+  describe('validation', function() {
+    var validAttrs = {
+      thingId: 't2_valid',
+    };
+
+    it('expects `thingId` to be a valid id', function() {
+      var account = new Account(validAttrs);
+
+      expect(account.validate()).to.equal(true);
+
+      account.set('thingId', 'invalid');
+
+      var errors = account.validate();
+
+      expect(errors.length).to.equal(1);
+      expect(errors[0]).to.equal('thingId');
+    });
+  });
+});

--- a/test/models/base.js
+++ b/test/models/base.js
@@ -116,4 +116,32 @@ describe('Base model', function() {
       });
     });
   });
+
+  describe('static members', function() {
+    describe('validators', function() {
+      describe('regex', function() {
+        it('returns `false` when the passed in string doesn\'t match the `expr`', function() {
+          expect(Base.validators.regex('foo', /^bar$/i)).to.equal(false);
+        });
+
+        it('returns `true` when the passed in string matches the `expr`', function() {
+          expect(Base.validators.regex('bar', /^bar$/i)).to.equal(true);
+        });
+      });
+
+      describe('thingId', function() {
+        it('returns `true` when `id` is undefined.', function() {
+          expect(Base.validators.thingId(void 0)).to.equal(true);
+        });
+
+        it('returns `false` when the passed in `id` isn\'t a valid `thingId`', function() {
+          expect(Base.validators.thingId('abc4')).to.equal(false);
+        });
+
+        it('returns `true` when the passed in `id` is a valid `thingId`', function() {
+          expect(Base.validators.thingId('t3_1')).to.equal(true);
+        });
+      });
+    });
+  });
 });

--- a/test/models/comment.js
+++ b/test/models/comment.js
@@ -1,0 +1,47 @@
+require('babel/register')({
+  extensions: ['.js', '.es6.js']
+});
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai)
+
+var Comment = require('../../src/api').models.Comment;
+
+describe('Comment model', function() {
+  describe('validation', function() {
+    var validAttrs = {
+      body: 'anything',
+      thingId: 't1_valid',
+    };
+
+    it('expects `thingId` to be a valid id', function() {
+      var comment = new Comment(validAttrs);
+
+      expect(comment.validate()).to.equal(true);
+
+      comment.set('thingId', 'invalid');
+
+      var errors = comment.validate();
+
+      expect(errors.length).to.equal(1);
+      expect(errors[0]).to.equal('thingId');
+    });
+
+    it('expects `body` to be at least 1 character', function() {
+      var comment = new Comment(validAttrs);
+
+      expect(comment.validate()).to.equal(true);
+
+      comment.set('body', '');
+
+      var errors = comment.validate();
+
+      expect(errors.length).to.equal(1);
+      expect(errors[0]).to.equal('body');
+    });
+  });
+});

--- a/test/models/link.js
+++ b/test/models/link.js
@@ -1,0 +1,33 @@
+require('babel/register')({
+  extensions: ['.js', '.es6.js']
+});
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai)
+
+var Link = require('../../src/api').models.Link;
+
+describe('Link model', function() {
+  describe('validation', function() {
+    var validAttrs = {
+      thingId: 't3_valid',
+    };
+
+    it('expects `thingId` to be a valid id', function() {
+      var link = new Link(validAttrs);
+
+      expect(link.validate()).to.equal(true);
+
+      link.set('thingId', 'invalid');
+
+      var errors = link.validate();
+
+      expect(errors.length).to.equal(1);
+      expect(errors[0]).to.equal('thingId');
+    });
+  });
+});


### PR DESCRIPTION
A `thingId` is a type prefix: `tN` and a base36 number separated by an underscore.

`t3_1` is a valid `thingId` that previously didn't meet the length requirement.

:eyeglasses: @ajacksified 