### PR TITLE
Do not delete the `subreddit` prop from comments

### DIFF
--- a/src/models/comment.es6.js
+++ b/src/models/comment.es6.js
@@ -4,7 +4,6 @@ import process from 'reddit-text-js';
 class Comment extends Base {
   constructor(props) {
     props._type = 'Comment';
-    delete props.subreddit;
 
     super(props);
 


### PR DESCRIPTION
I believe it was originally removed to save data dumped in the json of a comments page, but it's necessary in many cases (such as user activity), and can be removed in the view layer instead.

:eyeglasses: @curioussavage 