### PR TITLE
Configurable timeout

### DIFF
--- a/src/endpoints/v1.es6.js
+++ b/src/endpoints/v1.es6.js
@@ -57,7 +57,7 @@ function returnGETPromise (options, formatBody, log) {
      .get(options.uri)
      .set(options.headers || {})
      .query(options.query || {})
-     .timeout(TIMEOUT)
+     .timeout(options.timeout)
 
     if (options.env !== 'SERVER') {
       sa.retry(3)
@@ -185,6 +185,8 @@ class APIv1Endpoint {
     if (!options.env) {
       options.env = 'SERVER';
     }
+
+    options.timeout = this.config.timeout || TIMEOUT;
 
     if (options.userAgent) {
       headers['User-Agent'] = options.userAgent;


### PR DESCRIPTION
Send `timeout: Xms` in the constructor's configuration object to
configure the API timeout (`timeout: 5000` is default.)

:eyeglasses: @curioussavage 