### PR TITLE
Add a `deleted` property to comments

### DIFF
--- a/src/models/comment.es6.js
+++ b/src/models/comment.es6.js
@@ -8,6 +8,8 @@ class Comment extends Base {
     super(props);
 
     var comment = this;
+    
+    this.props.deleted = props.author === '[deleted]';
 
     this.validators = {
       body: function() {


### PR DESCRIPTION
The comparison to determine whether a `Comment` is deleted isn't great, but at least the app won't have to do it.