### PR TITLE
Typed response errors

### DIFF
--- a/src/api.es6.js
+++ b/src/api.es6.js
@@ -19,6 +19,7 @@ import WikiPageSettings from './models/wikiPageSettings';
 
 import NoModelError from './errors/noModelError';
 import ResponseError from './errors/responseError';
+import { DisconnectedError } from './errors/responseError';
 import ValidationError from './errors/validationError';
 
 const models = {
@@ -44,6 +45,7 @@ const errors = {
   NoModelError,
   ValidationError,
   ResponseError,
+  DisconnectedError,
 };
 
 export {

--- a/src/api.es6.js
+++ b/src/api.es6.js
@@ -17,6 +17,10 @@ import WikiRevision from './models/wikiRevision';
 import WikiPageListing from './models/wikiPageListing';
 import WikiPageSettings from './models/wikiPageSettings';
 
+import NoModelError from './errors/noModelError';
+import ResponseError from './errors/responseError';
+import ValidationError from './errors/validationError';
+
 const models = {
   Account,
   Award,
@@ -36,7 +40,14 @@ const models = {
   WikiPageSettings,
 };
 
+const errors = {
+  NoModelError,
+  ValidationError,
+  ResponseError,
+};
+
 export {
   v1,
   models,
+  errors,
 };

--- a/src/endpoints/v1.es6.js
+++ b/src/endpoints/v1.es6.js
@@ -21,6 +21,7 @@ import WikiPageSettings from '../models/wikiPageSettings';
 
 import NoModelError from '../errors/noModelError';
 import ValidationError from '../errors/validationError';
+import ResponseError from '../errors/responseError';
 
 const TYPES = {
   COMMENT: 't1',
@@ -100,14 +101,14 @@ function returnGETPromise (options, formatBody, log) {
         // example, unfound subs will redirect you to the search page.
         if (status === 302) {
           err.status = 404;
-          return reject(err);
+          return reject(new ResponseError(err, options.uri));
         }
 
-        return reject(err);
+        return reject(new ResponseError(err, options.uri));
       }
 
       if (!res.ok) {
-        return reject(res);
+        return reject(new ResponseError(res, options.uri));
       }
 
       try {
@@ -123,7 +124,7 @@ function returnGETPromise (options, formatBody, log) {
           body,
         });
       } catch (e) {
-        return reject(e);
+        return reject(new ResponseError(e, options.uri));
       }
     });
   });
@@ -278,11 +279,11 @@ class APIv1Endpoint {
           log('response', method, uri, options, status, err, Date.now() - time);
 
           if (err) {
-            return reject(err);
+            return reject(new ResponseError(err, uri));
           }
 
           if (!res.ok) {
-            return reject(res);
+            return reject(new ResponseError(res, uri));
           }
 
           if (cache.dataCache[dataType] && dataType && options.env === 'CLIENT') {
@@ -311,7 +312,7 @@ class APIv1Endpoint {
 
             resolve(body);
           } catch (e) {
-            reject(e);
+            reject(new ResponseError(e, uri));
           }
         });
     });

--- a/src/errors/responseError.es6.js
+++ b/src/errors/responseError.es6.js
@@ -1,11 +1,36 @@
-class ResponseError extends Error {
+export class DisconnectedError extends Error {
+  constructor(error, url) {
+    super(error);
+    Object.assign(this, error);
+    this.message = `URL ${url} not reachable. You are probably disconnected from the internet.`;
+  }
+}
+
+const codeMap = {
+  ECONNREFUSED: DisconnectedError,
+  ENOTFOUND: DisconnectedError,
+};
+
+export default class ResponseError extends Error {
   constructor (error, url) {
+    // Make sure an error and url were actually passed in
+    if (!error) { throw new Error('No error passed to ResponseError'); }
+    if (!url) { throw new Error('No url passed to ResponseError'); }
+
+    // Check if it's a disconnection error or something else weird
+    if (error.code && error.syscall) {
+      return ResponseError.getSystemLevelError(error, url);
+    }
+
     super(error);
     Object.assign(this, error);
 
     this.name = 'ResponseError';
     this.message = `Status ${error.status} returned from API request to ${url}`;
   }
-}
 
-export default ResponseError;
+  static getSystemLevelError (error, url) {
+    const E = codeMap[error.code] || Error;
+    return new E(error, url);
+  }
+}

--- a/src/errors/responseError.es6.js
+++ b/src/errors/responseError.es6.js
@@ -1,0 +1,11 @@
+class ResponseError extends Error {
+  constructor (error, url) {
+    super(error);
+    Object.assign(this, error);
+
+    this.name = 'ResponseError';
+    this.message = `Status ${error.status} returned from API request to ${url}`;
+  }
+}
+
+export default ResponseError;


### PR DESCRIPTION
This allows client code to check if a caught error is a ResponseError so that failures can be handled differently.

:eyeglasses: @schwers 