### PR TITLE
Add app=mweb-{env} to API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "reddit-text-js": "0.5.4",
     "restcache": "1.1.0",
     "superagent": "1.3.0",
-    "superagent-retry": "git://github.com/ajacksified/superagent-retry#7530ab7ab24ead56de2eeecc8d31d9a86896bc5a"
+    "superagent-retry": "git://github.com/ajacksified/superagent-retry#d39d7adbcd021d8ed09df440dba970c91fed9cd4"
   },
   "devDependencies": {
     "babel": "^5.0.0",

--- a/src/endpoints/v1.es6.js
+++ b/src/endpoints/v1.es6.js
@@ -74,10 +74,13 @@ function returnGETPromise (options, formatBody, log) {
 
     log('requesting', 'GET', options.uri, options);
 
+    const query = options.query || {};
+    query.app = `mweb-${options.env.toLowerCase()}`;
+
     let sa = superagent
       .get(options.uri)
+      .query(query)
       .set(options.headers || {})
-      .query(options.query || {})
       .timeout(options.timeout);
 
     if (options.env === 'SERVER') {
@@ -249,6 +252,10 @@ class APIv1Endpoint {
     let form = options.form || {};
     let headers = options.headers || {};
 
+
+    const query = options.query || {};
+    query.app = `mweb-${options.env.toLowerCase()}`;
+
     if (options.userAgent) {
       headers['User-Agent'] = options.userAgent;
     }
@@ -267,6 +274,7 @@ class APIv1Endpoint {
       log('requesting', method, uri, options);
 
       superagent[method](uri)
+        .query(query)
         .set(headers)
         .send(form)
         .type(type)

--- a/src/endpoints/v1.es6.js
+++ b/src/endpoints/v1.es6.js
@@ -75,7 +75,7 @@ function returnGETPromise (options, formatBody, log) {
     log('requesting', 'GET', options.uri, options);
 
     const query = options.query || {};
-    query.app = `mweb-${options.env.toLowerCase()}`;
+    query.app = `${this.config.appName}-${options.env.toLowerCase()}`;
 
     let sa = superagent
       .get(options.uri)
@@ -153,6 +153,8 @@ const CACHE_RULES = [
 
 class APIv1Endpoint {
   constructor (config = {}) {
+    config.appName = config.appName || 'snoode';
+
     this.config = config;
     this.log = this.log.bind(this);
 
@@ -254,7 +256,7 @@ class APIv1Endpoint {
 
 
     const query = options.query || {};
-    query.app = `mweb-${options.env.toLowerCase()}`;
+    query.app = `${this.config.appName}-${options.env.toLowerCase()}`;
 
     if (options.userAgent) {
       headers['User-Agent'] = options.userAgent;


### PR DESCRIPTION
Add an app name querystring so that it's easy to parse out when reading logs on the API side. Preferably this will be automated by a layer intercepting inbound requests rather than adding it to all clients, but this'll do for now.

:eyeglasses: @schwers @spladug 