### PR TITLE
Errors inherit from a fake error class.

### DIFF
--- a/src/errors/error.es6.js
+++ b/src/errors/error.es6.js
@@ -1,0 +1,15 @@
+export default class ErrorClass {
+  constructor (message) {
+    if (Error.hasOwnProperty('captureStackTrace')) {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      Object.defineProperty(this, 'stack', {
+        value: (new Error()).stack,
+      });
+
+      Object.defineProperty(this, 'message', {
+        value: message,
+      });
+    }
+  }
+}

--- a/src/errors/noModelError.es6.js
+++ b/src/errors/noModelError.es6.js
@@ -1,4 +1,6 @@
-class NoModelError extends Error {
+import FakeError from './error';
+
+class NoModelError extends FakeError {
   constructor (endpoint) {
     super(endpoint);
 

--- a/src/errors/responseError.es6.js
+++ b/src/errors/responseError.es6.js
@@ -1,4 +1,6 @@
-export class DisconnectedError extends Error {
+import FakeError from './error';
+
+export class DisconnectedError extends FakeError {
   constructor(error, url) {
     super(error);
     Object.assign(this, error);
@@ -11,7 +13,7 @@ const codeMap = {
   ENOTFOUND: DisconnectedError,
 };
 
-export default class ResponseError extends Error {
+export default class ResponseError extends FakeError {
   constructor (error, url) {
     // Make sure an error and url were actually passed in
     if (!error) { throw new Error('No error passed to ResponseError'); }

--- a/src/errors/validationError.es6.js
+++ b/src/errors/validationError.es6.js
@@ -1,4 +1,6 @@
-class ValidationError extends Error {
+import FakeError from './error';
+
+class ValidationError extends FakeError {
   constructor (name, model, errors) {
     super(name);
 


### PR DESCRIPTION
Inherit from a 'fake error' class - babel 6 removed a shim that allowed extending native classes. This fakes the functionality of Error so that error classifications (x instanceof y) work properly.

:eyeglasses: @nramadas 