### PR TITLE
Turn i.imgur.com links into imgur.com links

### DIFF
--- a/models/link.es6.js
+++ b/models/link.es6.js
@@ -1,6 +1,9 @@
 import Base from './base';
 import process from 'reddit-text-js';
 
+const I_IMGUR_DOMAIN = /i\.imgur\.com/;
+const I_IMGUR_URL_RE = /https?:\/\/i\.imgur\.com/;
+
 class Link extends Base {
   _type = 'Link';
 
@@ -122,6 +125,10 @@ class Link extends Base {
 
     props.cleanPermalink = this.unredditify(props.permalink);
     props.cleanUrl = this.unredditify(props.url);
+
+    props.cleanUrl = props.cleanUrl.replace(I_IMGUR_URL_RE, 'https://imgur.com');
+    props.url = props.url.replace(I_IMGUR_URL_RE, 'https://imgur.com');
+    props.domain = props.domain.replace(I_IMGUR_DOMAIN, 'imgur.com');
 
     props._type = this._type;
 


### PR DESCRIPTION
Spoke with Alex, we're supposed to turn i.imgur.com links -> imgur.com links. Seems like the best place to do this is at the API level. I'll follow up with comments if needed, but that's tricky. One concern with this is implementation is that it's unclear if we need to show the full link when someone edits their own post (and make sure it doesn't get PATCH'd into the prefixless version).