### PR TITLE
Base: get login directly from this.config

### DIFF
--- a/apis/base.es6.js
+++ b/apis/base.es6.js
@@ -25,17 +25,6 @@ class BaseAPI {
     this.config = base.config;
     this.cache = base.cache;
     this.event = base.event;
-
-    if (base.config) {
-      this.origin = base.config.origin;
-
-      if (base.config.origins) {
-        let name = this.constructor.name.toLowerCase();
-
-        this.origin = base.config.origins[name] ||
-                      this.config.origin;
-      }
-    }
   }
 
   // Used to format/unformat for caching; `links` or `comments`, for example.
@@ -76,7 +65,7 @@ class BaseAPI {
   }
 
   fullPath (method, query={}) {
-    return `${this.origin}/${this.path(method, query)}`;
+    return `${this.config.origin}/${this.path(method, query)}`;
   }
 
   formatMeta(res) {
@@ -147,7 +136,7 @@ class BaseAPI {
           err.status = 504;
         }
 
-        const origin = this.origin;
+        const origin = this.config.origin;
         const path = this.path(method, query);
 
         const fakeReq = { origin, path, method, query };
@@ -159,7 +148,7 @@ class BaseAPI {
   }
 
   rawSend(method, path, data, cb) {
-    const origin = this.origin;
+    const origin = this.config.origin;
 
     let s = superagent[method](`${origin}/${path}`);
     s.type('form');


### PR DESCRIPTION
If the instances config is updated as in the loginAndSave
method then the requests can't get the correct origin without
accessing the config directly instead of its own instance var set
at instantiation

:eyeglasses: @ajacksified and @schwers 


It didn't look like origins array is being passed in so I removed. Fixes requests after using loginAndSave in mancy