### PR TITLE
Update formatBody to take original method

### DIFF
--- a/apis/links.es6.js
+++ b/apis/links.es6.js
@@ -47,7 +47,7 @@ class Links extends BaseAPI {
 
   post (data) {
     const postData = {
-      api_type: 'data',
+      api_type: 'json',
       thing_id: data.thingId,
       title: data.title,
       kind: data.kind,
@@ -67,10 +67,10 @@ class Links extends BaseAPI {
     super.post(postData);
   }
 
-  formatBody(res, req) {
+  formatBody(res, req, method) {
     const { body } = res;
 
-    if (req.method === 'GET') {
+    if (method === 'get') {
       const { data } = body;
 
       if (data && data.children && data.children[0]) {
@@ -82,7 +82,7 @@ class Links extends BaseAPI {
       } else if (data) {
         return [];
       }
-    } else {
+    } else if (method !== 'del') {
       if (body.json && body.json.errors.length === 0) {
         return body.json.data;
       } else {


### PR DESCRIPTION
This fixes the case where DELETE doesn't send back a proper body and is
treated as an api request failure. (Since the API doesn't always send
back proper error codes, we were relying on JSON body format to
determine the error state.)

:eyeglasses: @schwers 